### PR TITLE
use-public-rspm: true i setup-r

### DIFF
--- a/workflow-templates/R-CMD-check.yml
+++ b/workflow-templates/R-CMD-check.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
       
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/workflow-templates/coverage.yml
+++ b/workflow-templates/coverage.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - name: Set up MySQL, ubuntu only
         run: |

--- a/workflow-templates/docker.yml
+++ b/workflow-templates/docker.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v5
       - name: R setup
         uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - name: Build package (tarball)
         run: R CMD build .
       - name: Lint Dockerfile

--- a/workflow-templates/harbor.yml
+++ b/workflow-templates/harbor.yml
@@ -26,6 +26,8 @@ jobs:
           dockerfile: "Dockerfile"
       - name: R setup
         uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - name: Build package (tarball)
         run: R CMD build .
       - name: Prepare tags

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/workflow-templates/pkgdown.yml
+++ b/workflow-templates/pkgdown.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/workflow-templates/snyk-vulnerability.yml
+++ b/workflow-templates/snyk-vulnerability.yml
@@ -26,6 +26,8 @@ jobs:
         echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
     - name: R setup
       uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
     - name: Build R package (tarball)
       run: R CMD build .
     - name: Build a Docker image

--- a/workflow-templates/trivy-vulnerability.yml
+++ b/workflow-templates/trivy-vulnerability.yml
@@ -23,6 +23,8 @@ jobs:
     
     - name: R setup
       uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
     
     - name: Build R package (tarball)
       run: R CMD build .


### PR DESCRIPTION
I følge dokumentasjonen:
> Use the public version of Posit package manager available at https://packagemanager.posit.co/ to serve binaries for Linux and Windows.